### PR TITLE
Add full installation of package to compile docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,9 +29,10 @@ jobs:
           cache-dependency-path: "pyproject.toml"
       - name: Install dependencies [pip]
         run: |
-          pip install --upgrade pip setuptools wheel
-          pip install -e .[doc]
-          pip install torch==${{ matrix.torch-version}} --extra-index-url https://download.pytorch.org/whl/cpu
+          python -m pip install --upgrade pip
+          pip install pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          source env_setup.sh
       - name: Install Pandoc [apt-get]
         run: |
           sudo apt-get -y install pandoc


### PR DESCRIPTION
The workflow to deploy docs actually needs the full TBX package install.

This PR adds it.

Otherwise, torch-sparse missing to render API docs

<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [ ] My pull request passes the Linting test.
- [ ] I added appropriate unit tests and I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My code is properly documented, using numpy docs conventions, and I made sure the documentation renders properly.
- [x] I linked to issues and PRs that are relevant to this PR.


## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->
